### PR TITLE
implemented html element configuration

### DIFF
--- a/htmlfilter/htmlfilter/filter.zep
+++ b/htmlfilter/htmlfilter/filter.zep
@@ -88,6 +88,10 @@ class Filter
     {
         let this->allowComments = allowComments;
         let this->config = config;
+
+        if isset(this->config["configureElements"]) {
+            this->configureElements(this->config["configureElements"]);
+        }
     }
 
     /**
@@ -282,5 +286,55 @@ class Filter
 
         return (isset(this->attributePermissionList[attribute])
                 && this->attributePermissionList[attribute] === 1);
+    }
+
+    /**
+     * Receives an configuration array for html elements
+     * Elements that do not exist will be created.
+     * If permission is not set, defaults to activate.
+     *
+     * @param array elements
+     *
+     * @return boolean
+     *
+     * @example
+     * [
+     *    ["name" => "script", "permission" => 0],
+     *    ["name" => "aside", "permission" => 1]
+     * ]
+     *
+     */
+    public function configureElements(elements) -> boolean
+    {
+        if empty(elements) || !is_array(elements) {
+            return false;
+        }
+
+        var element;
+        for element in elements {
+            if (!isset(element["name"])) {
+                continue;
+            }
+
+            this->changePermissionOfHtmlElement(
+                element["name"],
+                isset(element["permission"]) ? element["permission"] : 1
+            );
+
+            this->getParser()->addHtmlTagAsValid(element["name"]);
+        }
+
+        return true;
+    }
+
+    /**
+     * Alters the permission for a certain html element.
+     *
+     * @param string elementName
+     * @param int permission
+     */
+    public function changePermissionOfHtmlElement(string! elementName, int! permission=1)
+    {
+        let this->elementPermissionList[elementName] = permission;
     }
 }

--- a/htmlfilter/htmlfilter/filter.zep
+++ b/htmlfilter/htmlfilter/filter.zep
@@ -116,7 +116,7 @@ class Filter
     public function filterHtml(string! htmlString) -> string
     {
         let htmlString = this->clearComments(htmlString);
-        let htmlString = this->clearOddChars(htmlString);
+        let htmlString = this->clearMSChars(htmlString);
 
         var parsedHtml;
         let parsedHtml = this->getParser()->parse(htmlString);
@@ -225,12 +225,12 @@ class Filter
     }
 
     /**
-     * Removes Odd chars, usually created by ms-word
+     * Removes Odd chars, usually created by ms-word/excel..
      *
      * @param string text
      * @return string
      */
-    protected function clearOddChars(string! text)
+    protected function clearMSChars(string! text)
     {
         let text = preg_replace("`[\\x00-\\x08\\x0b-\\x0c\\x0e-\\x1f]`", "", text);
 

--- a/htmlfilter/htmlfilter/filter.zep
+++ b/htmlfilter/htmlfilter/filter.zep
@@ -7,14 +7,6 @@ namespace HtmlFilter;
 class Filter
 {
     /**
-     * Holds the passed configuration
-     * @var array config
-     */
-    protected config = [] {
-        set, get
-    };
-
-    /**
      * List of valid html elements
      * @var array htmlElements
      */
@@ -51,6 +43,13 @@ class Filter
     };
 
     /**
+     * @var boolean cleanMSCharacters
+     */
+    protected cleanMSCharacters = false {
+       get, set
+    };
+
+    /**
      * @var array elementBlacklist
      */
     protected elementPermissionList = [
@@ -84,13 +83,28 @@ class Filter
      * @param array config
      * @param boolean allowComments
      */
-    public function __construct(array config=[], boolean! allowComments=false)
+    public function __construct(array config=[])
     {
-        let this->allowComments = allowComments;
-        let this->config = config;
+        this->handleConfig(config);
+    }
 
-        if isset(this->config["configureElements"]) {
-            this->configureElements(this->config["configureElements"]);
+    /**
+     * Manages filter initial configuration
+     *
+     * @param array config
+     */
+    protected function handleConfig(array config)
+    {
+        if isset(config["allowComments"]) {
+            this->setAllowComments(config["allowComments"]);
+        }
+
+        if isset(config["configureElements"]) {
+            this->configureElements(config["configureElements"]);
+        }
+
+        if isset(config["cleanMSCharacters"]) {
+            this->setCleanMSCharacters(config["cleanMSCharacters"]);
         }
     }
 
@@ -220,7 +234,7 @@ class Filter
     {
         let text = preg_replace("`[\\x00-\\x08\\x0b-\\x0c\\x0e-\\x1f]`", "", text);
 
-        if isset(this->config["clean_ms_char"]) {
+        if this->cleanMSCharacters {
             var exclude = [
                 "\x7f" : "", "\x80" : "&#8364;", "\x81" : "", 
                 "\x83" : "&#402;", "\x85" : "&#8230;", "\x86" : "&#8224;",
@@ -229,26 +243,11 @@ class Filter
                 "\x8d" : "", "\x8e" : "&#381;", "\x8f" : "", "\x90" : "", 
                 "\x95" : "&#8226;", "\x96" : "&#8211;", "\x97" : "&#8212;", 
                 "\x98" : "&#732;", "\x99" : "&#8482;", "\x9a" : "&#353;", 
-                "\x9b" : "&#8250;", "\x9c" : "&#339;", "\x9d" : "", 
-                "\x9e" : "&#382;", "\x9f" : "&#376;"
+                "\x9b" : "&#8250;", "\x9c" : "&#339;", "\x9d" : "",
+                "\x9e" : "&#382;", "\x9f" : "&#376;","\x82" : "&#8218;",
+                "\x92" : "&#8217;", "\x93" : "&#8220;", "\x94" : "&#8221;",
+                "\x84" : "&#8222;", "\x91" : "&#8216;"
             ];
-
-            var key;
-            var value;
-
-            if this->config["clean_ms_char"] == 1 {
-                for key, value in [
-                    "\x82" : "&#8218;", "\x84" : "&#8222;", "\x91" : "&#8216;", 
-                    "\x92" : "&#8217;", "\x93" : "&#8220;", "\x94" : "&#8221;"
-                ] {
-                    let exclude[key] = value;
-                }
-            } else {
-                for key, value in ["\x82" : "'", "\x84" : "\"", "\x91" : "'", "\x92" : "'", "\x93" : "\"", "\x94" : "\""]
-                {
-                    let exclude[key] = value;
-                }
-            }
             
             let text = strtr(text, exclude);
         }

--- a/htmlfilter/htmlfilter/htmlparser.zep
+++ b/htmlfilter/htmlfilter/htmlparser.zep
@@ -264,4 +264,16 @@ class HtmlParser
     {
         return !empty(preg_match("/<\\/\\s?\\w*\\s?>/is", tagName));
     }
+
+    /**
+     * Adds a new html tag to the parser available tags
+     *
+     * @param string tagName
+     */
+    public function addHtmlTagAsValid(string! tagName)
+    {
+        if !in_array(tagName, this->validHtmlTags) {
+            let this->validHtmlTags[] = tagName;
+        }
+    }
 }


### PR DESCRIPTION
Now is possible to add new elements, or disable already included ones

you may pass a new config parameter into filter:
```php
//disable all usage of <script>, and enables <aside>
$config = array(
    'configureElements' => array(
        array('name'=>'script', 'permission' => 0),
        array('name'=>'aside', 'permission' => 1),
    )
);

$filter = new HtmlFilter\Filter($config);
```

Or you may simply pass them into configureElements method:
```php
$filter = new HtmlFilter\Filter();

$elementConfiguration = array(
    array('name'=>'script', 'permission' => 0),
    array('name'=>'aside', 'permission' => 1),
);

$filter->configureElements($elementConfiguration);
```